### PR TITLE
Feature/dte 319/bagit available rename

### DIFF
--- a/tre_event_lib/README.md
+++ b/tre_event_lib/README.md
@@ -79,7 +79,9 @@ To build Python `whl` package with API and schemas:
 ```bash
 pip3 install jsonschema
 cd tre_event_lib
-./build.sh
+
+# Pass a version to not use latest git tag version
+./build.sh ${version_if_not_latest_git_tag}
 ```
 
 ## Testing In Docker

--- a/tre_event_lib/README.md
+++ b/tre_event_lib/README.md
@@ -80,8 +80,8 @@ To build Python `whl` package with API and schemas:
 pip3 install jsonschema
 cd tre_event_lib
 
-# Pass a version to not use latest git tag version
-./build.sh ${version_if_not_latest_git_tag}
+# To not use the latest git tag version, pass the optional version argument
+./build.sh ${version_instead_of_latest_git_tag}
 ```
 
 ## Testing In Docker

--- a/tre_event_lib/tre_event_lib/tests/test_bagit_available.py
+++ b/tre_event_lib/tre_event_lib/tests/test_bagit_available.py
@@ -1,5 +1,5 @@
 """
-Tests for new-bagit event.
+Tests for bagit-available event.
 """
 import unittest
 import test_utils
@@ -8,24 +8,24 @@ from tre_event_lib import tre_event_api
 
 
 event_valid = test_utils.load_test_event(
-    event_file_name='new-bagit.json'
+    event_file_name='bagit-available.json'
 )
 
 event_invalid_event_name = test_utils.load_test_event(
-    event_file_name='new-bagit-invalid-event-name.json'
+    event_file_name='bagit-available-invalid-event-name.json'
 )
 
-EVENT_NAME = 'new-bagit'
+EVENT_NAME = 'bagit-available'
 
 
 class TestNewBagitSchema(unittest.TestCase):
-    """Tests for new-bagit event."""
+    """Tests for bagit-available event."""
     def test_event_valid(self):
-        """Test new-bagit schema."""
+        """Test bagit-available schema."""
         tre_event_api.validate_event(event=event_valid)
 
     def test_event_invalid_event_name(self):
-        """Test new-bagit schema fails with invalid event-name."""
+        """Test bagit-available schema fails with invalid event-name."""
         try:
             tre_event_api.validate_event(
                 event=event_invalid_event_name,
@@ -33,5 +33,5 @@ class TestNewBagitSchema(unittest.TestCase):
             
             self.fail('Did not get expected exception')
         except jsonschema.exceptions.ValidationError as validation_error:
-            expected = "'oops' is not one of ['new-bagit']"
+            expected = "'oops' is not one of ['bagit-available']"
             self.assertTrue(expected in str(validation_error))

--- a/tre_event_lib/tre_event_lib/tests/test_bagit_received.py
+++ b/tre_event_lib/tre_event_lib/tests/test_bagit_received.py
@@ -42,9 +42,9 @@ class TestBagItReceivedSchema(unittest.TestCase):
         try:
             tre_event_api.validate_event(
                 event=event_invalid_event_name,
-                schema_name=EVENT_NAME)  # intended schema (as name invalid)
+                schema_name=EVENT_NAME)  # specify as test event name is invalid
 
             self.fail('Did not get expected exception')
         except jsonschema.exceptions.ValidationError as v_err:
-            expected = "'new-bagit' is not one of ['bagit-received']"
+            expected = "'nosuch' is not one of ['bagit-received']"
             self.assertTrue(expected in str(v_err))

--- a/tre_event_lib/tre_event_lib/tests/test_events/bagit-available-invalid-event-name.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/bagit-available-invalid-event-name.json
@@ -12,7 +12,7 @@
         "type": null
     },
     "parameters": {
-        "new-bagit": {
+        "bagit-available": {
             "resource": {
                 "resource-type": "",
                 "access-type": "",

--- a/tre_event_lib/tre_event_lib/tests/test_events/bagit-available.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/bagit-available.json
@@ -8,11 +8,11 @@
         "name": "foo",
         "environment": "foo",
         "process": "foo",
-        "event-name": "new-bagit",
+        "event-name": "bagit-available",
         "type": null
     },
     "parameters": {
-        "new-bagit": {
+        "bagit-available": {
             "resource": {
                 "resource-type": "",
                 "access-type": "",

--- a/tre_event_lib/tre_event_lib/tests/test_events/bagit-received-invalid-event-name.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/bagit-received-invalid-event-name.json
@@ -10,7 +10,7 @@
         "name": "foo",
         "environment": "foo",
         "process": "foo",
-        "event-name": "new-bagit",
+        "event-name": "nosuch",
         "type": null
     },
     "parameters": {

--- a/tre_event_lib/tre_event_lib/tests/test_tre_event_lib.py
+++ b/tre_event_lib/tre_event_lib/tests/test_tre_event_lib.py
@@ -7,18 +7,18 @@ import jsonschema
 import test_utils
 from tre_event_lib import tre_event_api
 
-EVENT_NEW_BAGIT = 'new-bagit'
+EVENT_BAGIT_AVAILABLE = 'bagit-available'
 ENVIRONMENT = 'unittest'
 TRE_EVENT = 'tre-event'
 TRE_EVENT_ID_KEY = '$id'
 TRE_EVENT_ID = 'https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-event'
 
 # Load example event and extract parameters section for test
-event_new_bagit = test_utils.load_test_event(
-    event_file_name='new-bagit.json'
+event_bagit_available = test_utils.load_test_event(
+    event_file_name='bagit-available.json'
 )
 
-event_new_bagit_parameters = event_new_bagit['parameters']
+event_bagit_available_parameters = event_bagit_available['parameters']
 
 
 class TestEventLibCreateEvent(unittest.TestCase):
@@ -31,8 +31,8 @@ class TestEventLibCreateEvent(unittest.TestCase):
             environment=ENVIRONMENT,
             producer='alpha',
             process='bravo',
-            event_name=EVENT_NEW_BAGIT,
-            parameters=event_new_bagit_parameters
+            event_name=EVENT_BAGIT_AVAILABLE,
+            parameters=event_bagit_available_parameters
         )
 
         self.assertTrue(isinstance(event_1, dict))
@@ -54,16 +54,16 @@ class TestEventLibCreateEvent(unittest.TestCase):
             environment=ENVIRONMENT,
             producer='alpha',
             process='foo',
-            event_name=EVENT_NEW_BAGIT,
-            parameters=event_new_bagit_parameters
+            event_name=EVENT_BAGIT_AVAILABLE,
+            parameters=event_bagit_available_parameters
         )
 
         event_2 = tre_event_api.create_event(
             environment=ENVIRONMENT,
             producer='bravo',
             process='bar',
-            event_name=EVENT_NEW_BAGIT,
-            parameters=event_new_bagit_parameters,
+            event_name=EVENT_BAGIT_AVAILABLE,
+            parameters=event_bagit_available_parameters,
             prior_event=event_1
         )
 
@@ -71,8 +71,8 @@ class TestEventLibCreateEvent(unittest.TestCase):
             environment=ENVIRONMENT,
             producer='charlie',
             process='baz',
-            event_name=EVENT_NEW_BAGIT,
-            parameters=event_new_bagit_parameters,
+            event_name=EVENT_BAGIT_AVAILABLE,
+            parameters=event_bagit_available_parameters,
             prior_event=event_2
         )
 
@@ -99,7 +99,7 @@ class TestEventLibCreateEvent(unittest.TestCase):
                 producer='alpha',
                 process='bravo',
                 event_name='no-such-event-as-this-exists',
-                parameters=event_new_bagit_parameters
+                parameters=event_bagit_available_parameters
             )
 
             self.fail('Did not get expected exception')
@@ -116,8 +116,8 @@ class TestEventLibValidateEvent(unittest.TestCase):
                 environment=ENVIRONMENT,
                 producer='alpha',
                 process='bravo',
-                event_name=EVENT_NEW_BAGIT,
-                parameters=event_new_bagit_parameters
+                event_name=EVENT_BAGIT_AVAILABLE,
+                parameters=event_bagit_available_parameters
             )
 
             del event_1['UUIDs']
@@ -135,7 +135,7 @@ class TestEventLibHelperMethods(unittest.TestCase):
         schema_list = tre_event_api.get_event_list()
         self.assertTrue(isinstance(schema_list, list))
         self.assertTrue(TRE_EVENT in schema_list)
-        self.assertTrue(EVENT_NEW_BAGIT in schema_list)
+        self.assertTrue(EVENT_BAGIT_AVAILABLE in schema_list)
 
     def test_get_schema(self):
         """Confirm get_event_schema works."""

--- a/tre_schemas/bagit-available.json
+++ b/tre_schemas/bagit-available.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/new-bagit",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/bagit-available",
   "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-event",
   "type": "object",
   "properties": {
@@ -10,7 +10,7 @@
         "event-name": {
           "type": "string",
           "enum": [
-            "new-bagit"
+            "bagit-available"
           ]
         }
       }
@@ -18,7 +18,7 @@
     "parameters": {
       "type": "object",
       "properties": {
-        "new-bagit": {
+        "bagit-available": {
           "type": "object",
           "properties": {
             "resource": {
@@ -75,7 +75,7 @@
         }
       },
       "required": [
-        "new-bagit"
+        "bagit-available"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
This update renames the `new-bagit` event to `bagit-available`.