### PR TITLE
DTE-328-Add in-line descriptions to TRE Json Schemas

### DIFF
--- a/tre_schemas/bagit-available.json
+++ b/tre_schemas/bagit-available.json
@@ -11,7 +11,8 @@
           "type": "string",
           "enum": [
             "bagit-available"
-          ]
+          ],
+          "description": "The name of the event being propagated for this event it should always be bagit-available"
         }
       }
     },
@@ -25,13 +26,16 @@
               "type": "object",
               "properties": {
                 "resource-type": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "What form the resource takes i.e. Object"
                 },
                 "access-type": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "The medium in which the resource is accessed, i.e. url, ftp"
                 },
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "a uri that describes the logical or physical resource location i.e. A url"
                 }
               },
               "required": [
@@ -44,16 +48,20 @@
               "type": "object",
               "properties": {
                 "resource-type": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "What form the resource takes i.e. Object"
                 },
                 "access-type": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "The medium in which the resource is accessed, i.e. url, ftp"
                 },
                 "validation-method": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "The process used to determine the integrity of the object i.e. SHA256"
                 },
                 "value": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "BagIt archive file pre-signed URL"
                 }
               },
               "required": [
@@ -64,7 +72,8 @@
               ]
             },
             "reference": {
-              "type": "string"
+              "type": "string",
+              "description": "The Urn of the object to which the consignment refers, i.e. a filename"
             }
           },
           "required": [

--- a/tre_schemas/bagit-received.json
+++ b/tre_schemas/bagit-received.json
@@ -11,7 +11,8 @@
           "type": "string",
           "enum": [
             "bagit-received"
-          ]
+          ],
+          "description": "The name of the event being propagated for this event it should always be bagit-received"
         }
       }
     },
@@ -25,10 +26,12 @@
               "type": "string"
             },
             "s3-bucket": {
-              "type": "string"
+              "type": "string",
+              "description": "The TRE S3 bucket used to extract and verify the BagIt"
             },
             "s3-bagit-name": {
-              "type": "string"
+              "type": "string",
+              "description": "The TRE S3 path of the saved input BagIt file"
             }
           },
           "required": [

--- a/tre_schemas/bagit-validated.json
+++ b/tre_schemas/bagit-validated.json
@@ -11,7 +11,8 @@
           "type": "string",
           "enum": [
             "bagit-validated"
-          ]
+          ],
+          "description": "The name of the event being propagated for this event it should always be bagit-validated"
         }
       }
     },
@@ -22,33 +23,40 @@
           "type": "object",
           "properties": {
             "reference": {
-              "type": "string"
+              "type": "string",
+              "description": "From input message parameters.new-bagit.reference"
             },
             "s3-bucket": {
-              "type": "string"
+              "type": "string",
+              "description": "The TRE S3 bucket used to extract and verify the BagIt"
             },
             "s3-bagit-name": {
-              "type": "string"
+              "type": "string",
+              "description": "The TRE S3 path of the saved input BagIt file"
             },
             "s3-object-root": {
-              "type": "string"
+              "type": "string",
+              "description": "The TRE S3 folder where the input BagIt file is extracted"
             },
             "validated-files": {
               "type": "object",
               "properties": {
                 "path": {
-                  "type": "string"
+                  "type": "string",
+                  "description":"A dictionary with lists of validated files"
                 },
                 "root": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The TRE S3 folder where the input BagIt file is extracted"
                   }
                 },
                 "data": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "a list of the files contained within the consignment, including the full filepath"
                   }
                 }
               },

--- a/tre_schemas/bagit-validation-error.json
+++ b/tre_schemas/bagit-validation-error.json
@@ -11,7 +11,8 @@
           "type": "string",
           "enum": [
             "bagit-validation-error"
-          ]
+          ],
+          "description": "The name of the event being propagated for this event it should always be bagit-validation-error"
         }
       }
     },
@@ -22,11 +23,13 @@
           "type": "object",
           "properties": {
             "reference": {
-              "type": "string"
+              "type": "string",
+              "description": "From input message parameters.new-bagit.reference"
             },
             "errors": {
               "type": "array",
-              "items": {}
+              "items": {},
+              "description": "A list of errors from the validate-bagit process"
             }
           },
           "required": [

--- a/tre_schemas/dri-preingest-sip-available.json
+++ b/tre_schemas/dri-preingest-sip-available.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema",
     "$id":"https://nationalarchives.gov.uk/da-transform/tre/schemas/dri-preingest-sip-available",
     "$ref":"https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-event",
     "type": "object",
@@ -8,7 +8,8 @@
             "properties": {
                 "event-name": {
                     "type": "string",
-                    "enum": ["dri-preingest-sip-available"]
+                    "enum": ["dri-preingest-sip-available"],
+                    "description": "The name of the event being propagated for this event it should always be dri-preingest-sip-available"
                 }
             }
         },

--- a/tre_schemas/tre-event.json
+++ b/tre_schemas/tre-event.json
@@ -4,10 +4,12 @@
     "type": "object",
     "properties": {
         "version": {
-            "type": "string"
+            "type": "string",
+            "description": "Version of the message being sent"
         },
         "timestamp": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Creation time in nanoseconds UTC"
         },
         "UUIDs": {
             "type": "array",
@@ -17,7 +19,8 @@
                 "patternProperties": {
                     "^[a-zA-Z0-9_-]+-UUID$": {
                         "type": "string",
-                        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+                        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+                        "description": "A universally unique identifier, the suffix must match the producer field, i.e. TRE-UUID"
                     }
                 },
                 "additionalProperties": false
@@ -26,12 +29,15 @@
         },
         "producer": {
             "type": "object",
+            "description": "Dictionary specifying the event-name being sent and details about the producer",
             "properties": {
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The message producer (e.g. TRE, TDR, etc)"
                 },
                 "process": {
-                    "type": ["string", "null"]
+                    "type": ["string", "null"],
+                    "description": "The name of the process that creates the message (e.g. validate-bagit)"
                 },
                 "type": {
                     "type": [
@@ -42,14 +48,17 @@
                         "judgment",
                         "standard",
                         null
-                    ]
+                    ],
+                    "description": "The name of the consignment type being passed; standard, judgment or null"
                 },
                 "environment": {
-                    "type": ["string", "null"]
+                    "type": ["string", "null"],
+                    "description": "The name of the environment that creates the message (e.g. test, production, etc)"
                 },
                 "event-name": {
                     "type": "string",
-                    "pattern": "^[.a-zA-Z0-9_-]+$"
+                    "pattern": "^[.a-zA-Z0-9_-]+$",
+                    "description": "The name of the event being propagated (e.g. new-bagit, bagit-validated, etc)"
                 },
                 "version": {
                     "type": ["string", "object"]


### PR DESCRIPTION
[DTE-328](https://national-archives.atlassian.net/browse/DTE-328?atlOrigin=eyJpIjoiOTdiZjA0YmU1MjVhNDMxNWE1NzU0YTQyOGNjYTZlNDkiLCJwIjoiaiJ9)

The TRE Json shemas should have inline descriptions So that users can data expected standards

- [x] All schemas have the appropriate descriptive fields filled in