### PR TITLE
Feature/dte 385/v2 run parser json schemas

### DIFF
--- a/tre_event_lib/tre_event_lib/tests/test_events/judgment-available-invalid-event-name.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/judgment-available-invalid-event-name.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.0.0",
+    "timestamp": 42,
+    "UUIDs": [
+        {"foo-UUID": "8d02ec4d-550c-4af7-849b-c5cef5f8e820"}
+    ],
+    "producer": {
+        "name": "foo",
+        "environment": "foo",
+        "process": "foo",
+        "event-name": "invalid-event-name-test",
+        "type": null
+    },
+    "parameters": {
+        "document": {
+            "s3-bucket": "alpha",
+            "s3-key": "bravo"
+        },
+        "attachments": [
+            {
+                "s3-bucket": "alpha",
+                "s3-key": "charlie/delta"
+            },
+            {
+                "s3-bucket": "alpha",
+                "s3-key": "echo"
+            }
+        ],
+        "reference" : ""
+    }
+}

--- a/tre_event_lib/tre_event_lib/tests/test_events/judgment-available.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/judgment-available.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.0.0",
+    "timestamp": 42,
+    "UUIDs": [
+        {"foo-UUID": "8d02ec4d-550c-4af7-849b-c5cef5f8e820"}
+    ],
+    "producer": {
+        "name": "foo",
+        "environment": "foo",
+        "process": "foo",
+        "event-name": "judgment-available",
+        "type": null
+    },
+    "parameters": {
+        "document": {
+            "s3-bucket": "alpha",
+            "s3-key": "bravo"
+        },
+        "attachments": [
+            {
+                "s3-bucket": "alpha",
+                "s3-key": "charlie/delta"
+            },
+            {
+                "s3-bucket": "alpha",
+                "s3-key": "echo"
+            }
+        ],
+        "reference" : ""
+    }
+}

--- a/tre_event_lib/tre_event_lib/tests/test_events/judgment-parser-error-invalid-event-name.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/judgment-parser-error-invalid-event-name.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "timestamp": 42,
+    "UUIDs": [
+        {
+            "foo-UUID": "8d02ec4d-550c-4af7-849b-c5cef5f8e820"
+        }
+    ],
+    "producer": {
+        "name": "foo",
+        "environment": "foo",
+        "process": "foo",
+        "event-name": "invalid-event-name-jpe",
+        "type": null
+    },
+    "parameters": {
+        "reference": "",
+        "errors": [""]
+    }
+}

--- a/tre_event_lib/tre_event_lib/tests/test_events/judgment-parser-error.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/judgment-parser-error.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "timestamp": 42,
+    "UUIDs": [
+        {
+            "foo-UUID": "8d02ec4d-550c-4af7-849b-c5cef5f8e820"
+        }
+    ],
+    "producer": {
+        "name": "foo",
+        "environment": "foo",
+        "process": "foo",
+        "event-name": "judgment-parser-error",
+        "type": null
+    },
+    "parameters": {
+        "reference": "",
+        "errors": [""]
+    }
+}

--- a/tre_event_lib/tre_event_lib/tests/test_events/parsed-judgment-available-invalid-event-name.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/parsed-judgment-available-invalid-event-name.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0.0",
+    "timestamp": 42,
+    "UUIDs": [
+        {"foo-UUID": "8d02ec4d-550c-4af7-849b-c5cef5f8e820"}
+    ],
+    "producer": {
+        "name": "foo",
+        "environment": "foo",
+        "process": "foo",
+        "event-name": "invalid-event-name-pja",
+        "type": null
+    },
+    "parameters": {
+        "s3-location": {
+            "s3-bucket": "alpha",
+            "s3-key": "bravo/charlie"
+        },
+        "reference" : "CR-2022-A2C",
+        "parser": {
+            "uri": "https://caselaw.nationalarchives.gov.uk/id/ewhc/qb/2022/123",
+            "court": "EWHC-QBD",
+            "cite": "[2022] EWHC 123 (QB)",
+            "date": "2022-04-10",
+            "name": "foo v bar",
+            "images": [
+                {
+                    "s3-bucket": "alpha",
+                    "s3-key": "bravo/charlie/delta/example-image-1.png"
+                }
+            ]
+        },
+        "attachments": [
+            {
+                "s3-bucket": "foxtrot",
+                "s3-key": "golf/hotel/attachment.ext"
+            }
+        ]
+    }
+}

--- a/tre_event_lib/tre_event_lib/tests/test_events/parsed-judgment-available.json
+++ b/tre_event_lib/tre_event_lib/tests/test_events/parsed-judgment-available.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0.0",
+    "timestamp": 42,
+    "UUIDs": [
+        {"foo-UUID": "8d02ec4d-550c-4af7-849b-c5cef5f8e820"}
+    ],
+    "producer": {
+        "name": "foo",
+        "environment": "foo",
+        "process": "foo",
+        "event-name": "parsed-judgment-available",
+        "type": null
+    },
+    "parameters": {
+        "s3-location": {
+            "s3-bucket": "alpha",
+            "s3-key": "bravo/charlie"
+        },
+        "reference" : "CR-2022-A2C",
+        "parser": {
+            "uri": "https://caselaw.nationalarchives.gov.uk/id/ewhc/qb/2022/123",
+            "court": "EWHC-QBD",
+            "cite": "[2022] EWHC 123 (QB)",
+            "date": "2022-04-10",
+            "name": "foo v bar",
+            "images": [
+                {
+                    "s3-bucket": "alpha",
+                    "s3-key": "bravo/charlie/delta/example-image-1.png"
+                }
+            ]
+        },
+        "attachments": [
+            {
+                "s3-bucket": "foxtrot",
+                "s3-key": "golf/hotel/attachment.ext"
+            }
+        ]
+    }
+}

--- a/tre_event_lib/tre_event_lib/tests/test_judgment_available.py
+++ b/tre_event_lib/tre_event_lib/tests/test_judgment_available.py
@@ -1,0 +1,36 @@
+"""
+Tests for judgment-available event.
+"""
+import unittest
+import test_utils
+import jsonschema
+from tre_event_lib import tre_event_api
+
+
+event_valid = test_utils.load_test_event(
+    event_file_name='judgment-available.json'
+)
+
+event_invalid_event_name = test_utils.load_test_event(
+    event_file_name='judgment-available-invalid-event-name.json')
+
+EVENT_NAME = 'judgment-available'
+
+
+class TestJudgmentAvailable(unittest.TestCase):
+    """Tests for judgment-available event."""
+    def test_event_valid(self):
+        """Test judgment-available schema."""
+        tre_event_api.validate_event(event=event_valid)
+
+    def test_event_invalid_event_name(self):
+        """Test judgment-available schema fails when event-name invalid."""
+        try:
+            tre_event_api.validate_event(
+                event=event_invalid_event_name,
+                schema_name=EVENT_NAME)  # intended schema (as name invalid)
+            
+            self.fail('Did not get expected exception')
+        except jsonschema.exceptions.ValidationError as validation_error:
+            expected = "'invalid-event-name-test' is not one of ['judgment-available']"
+            self.assertTrue(expected in str(validation_error))

--- a/tre_event_lib/tre_event_lib/tests/test_judgment_parser_error.py
+++ b/tre_event_lib/tre_event_lib/tests/test_judgment_parser_error.py
@@ -1,0 +1,36 @@
+"""
+Tests for judgment-parser-error event.
+"""
+import unittest
+import test_utils
+import jsonschema
+from tre_event_lib import tre_event_api
+
+
+event_valid = test_utils.load_test_event(
+    event_file_name='judgment-parser-error.json'
+)
+
+event_invalid_event_name = test_utils.load_test_event(
+    event_file_name='judgment-parser-error-invalid-event-name.json')
+
+EVENT_NAME = 'judgment-parser-error'
+
+
+class TestJudgmentAvailable(unittest.TestCase):
+    """Tests for judgment-parser-error event."""
+    def test_event_valid(self):
+        """Test judgment-parser-error schema."""
+        tre_event_api.validate_event(event=event_valid)
+
+    def test_event_invalid_event_name(self):
+        """Test judgment-parser-error schema fails when event-name invalid."""
+        try:
+            tre_event_api.validate_event(
+                event=event_invalid_event_name,
+                schema_name=EVENT_NAME)  # intended schema (as name invalid)
+            
+            self.fail('Did not get expected exception')
+        except jsonschema.exceptions.ValidationError as validation_error:
+            expected = "'invalid-event-name-jpe' is not one of ['judgment-parser-error']"
+            self.assertTrue(expected in str(validation_error))

--- a/tre_event_lib/tre_event_lib/tests/test_parsed_judgment_available.py
+++ b/tre_event_lib/tre_event_lib/tests/test_parsed_judgment_available.py
@@ -1,0 +1,36 @@
+"""
+Tests for parsed-judgment-available event.
+"""
+import unittest
+import test_utils
+import jsonschema
+from tre_event_lib import tre_event_api
+
+
+event_valid = test_utils.load_test_event(
+    event_file_name='parsed-judgment-available.json'
+)
+
+event_invalid_event_name = test_utils.load_test_event(
+    event_file_name='parsed-judgment-available-invalid-event-name.json')
+
+EVENT_NAME = 'parsed-judgment-available'
+
+
+class TestJudgmentAvailable(unittest.TestCase):
+    """Tests for parsed-judgment-available event."""
+    def test_event_valid(self):
+        """Test parsed-judgment-available schema."""
+        tre_event_api.validate_event(event=event_valid)
+
+    def test_event_invalid_event_name(self):
+        """Test parsed-judgment-available schema fails when event-name invalid."""
+        try:
+            tre_event_api.validate_event(
+                event=event_invalid_event_name,
+                schema_name=EVENT_NAME)  # intended schema (as name invalid)
+            
+            self.fail('Did not get expected exception')
+        except jsonschema.exceptions.ValidationError as validation_error:
+            expected = "'invalid-event-name-pja' is not one of ['parsed-judgment-available']"
+            self.assertTrue(expected in str(validation_error))

--- a/tre_schemas/judgment-available.json
+++ b/tre_schemas/judgment-available.json
@@ -21,7 +21,7 @@
       "properties": {
         "document": {
           "$ref": "#/$defs/s3-object",
-          "description": "S3 location of document for parses"
+          "description": "S3 location of document for parser"
         },
         "attachments": {
           "description": "S3 locations of attachments for parser",

--- a/tre_schemas/judgment-available.json
+++ b/tre_schemas/judgment-available.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/judgment-available",
+  "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-event",
+  "type": "object",
+  "properties": {
+    "producer": {
+      "type": "object",
+      "properties": {
+        "event-name": {
+          "type": "string",
+          "enum": [
+            "judgment-available"
+          ],
+          "description": "The name of the event"
+        }
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "document": {
+          "$ref": "#/$defs/s3-object",
+          "description": "S3 location of document for parses"
+        },
+        "attachments": {
+          "description": "S3 locations of attachments for parser",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "$ref": "#/$defs/s3-object",
+            "description": "S3 location of an attachment"
+          }
+        },
+        "reference": {
+          "description": "The consignment reference of the document to be parsed",
+          "type": "string",
+          "minLength": 0
+        },
+        "required": [
+          "document",
+          "attachments",
+          "reference"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "required": [
+      "parameters"
+    ],
+    "additionalProperties": false
+  },
+  "$defs": {
+    "s3-object": {
+      "type": "object",
+      "description": "S3 object location",
+      "properties": {
+        "s3-bucket": {
+          "description": "S3 object bucket",
+          "type": "string",
+          "minLength": 1
+        },
+        "s3-key": {
+          "description": "S3 object key",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "s3-bucket",
+        "s3-key"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tre_schemas/judgment-parser-error.json
+++ b/tre_schemas/judgment-parser-error.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/judgment-parser-error",
+  "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-event",
+  "type": "object",
+  "properties": {
+    "producer": {
+      "type": "object",
+      "properties": {
+        "event-name": {
+          "type": "string",
+          "enum": [
+            "judgment-parser-error"
+          ],
+          "description": "The name of the event"
+        }
+      }
+    },
+    "parameters": {
+      "type": "object",
+      "description": "The event's parameters",
+      "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-error"
+    },
+    "required": [
+      "parameters"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/tre_schemas/parsed-judgment-available.json
+++ b/tre_schemas/parsed-judgment-available.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/judgment-available",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/parsed-judgment-available",
   "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-event",
   "type": "object",
   "properties": {
@@ -10,7 +10,7 @@
         "event-name": {
           "type": "string",
           "enum": [
-            "judgment-available"
+            "parsed-judgment-available"
           ],
           "description": "The name of the event"
         }
@@ -18,25 +18,31 @@
     },
     "parameters": {
       "type": "object",
+      "description": "The event's parameters",
       "additionalProperties": false,
       "properties": {
-        "document": {
+        "s3-location": {
           "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-s3-location",
-          "description": "S3 location of document for parser"
+          "description": "Parser output S3 location"
+        },
+        "reference": {
+          "description": "The consignment reference associated with the parsed document",
+          "type": "string",
+          "minLength": 0
+        },
+        "parser": {
+          "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-parser-output",
+          "description": "Parser output data"
         },
         "attachments": {
           "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-attachments",
           "description": "S3 location of parser attachments"
         },
-        "reference": {
-          "description": "The consignment reference of the document to be parsed",
-          "type": "string",
-          "minLength": 0
-        },
         "required": [
-          "document",
-          "attachments",
-          "reference"
+          "s3-location",
+          "reference",
+          "parser",
+          "attachments"
         ],
         "additionalProperties": false
       }

--- a/tre_schemas/tre-attachments.json
+++ b/tre_schemas/tre-attachments.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-attachments",
+  "description": "S3 location of parser attachments",
+  "additionalProperties": false,
+  "type": "array",
+  "minItems": 0,
+  "items": {
+    "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-s3-location",
+    "description": "S3 location of an attachment"
+  }
+}

--- a/tre_schemas/tre-error.json
+++ b/tre_schemas/tre-error.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-error",
+  "type": "object",
+  "description": "TRE error event details",
+  "additionalProperties": false,
+  "properties": {
+    "additionalProperties": false,
+    "reference": {
+      "type": "string",
+      "minLength": 0,
+      "description": "Consignment reference"
+    },
+    "errors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {},
+      "description": "A list of errors"
+    },
+    "required": [
+      "reference",
+      "errors"
+    ]
+  }
+}

--- a/tre_schemas/tre-parser-output.json
+++ b/tre_schemas/tre-parser-output.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-parser-output",
+  "type": "object",
+  "description": "Parser output fields",
+  "additionalProperties": false,
+  "properties": {
+    "uri": {
+      "description": "The judgment's URI",
+      "type": "string",
+      "minLength": 0
+    },
+    "court": {
+      "description": "The judgment's court",
+      "type": "string",
+      "minLength": 0
+    },
+    "cite": {
+      "description": "The judgment's citation",
+      "type": "string",
+      "minLength": 0
+    },
+    "date": {
+      "description": "The judgment's date",
+      "type": "string",
+      "minLength": 0
+    },
+    "name": {
+      "description": "The judgment's name",
+      "type": "string",
+      "minLength": 0
+    },
+    "images": {
+      "description": "List of judgment image files",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "$ref": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-s3-location",
+        "description": "Parser output image S3 location"
+      }
+    },
+    "required": [
+      "uri",
+      "court"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/tre_schemas/tre-s3-location.json
+++ b/tre_schemas/tre-s3-location.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nationalarchives.gov.uk/da-transform/tre/schemas/tre-s3-location",
+  "type": "object",
+  "description": "An S3 location; may be to an object, or could just be a path prefix",
+  "additionalProperties": false,
+  "properties": {
+    "s3-bucket": {
+      "description": "An S3 bucket name",
+      "type": "string",
+      "minLength": 1
+    },
+    "s3-key": {
+      "description": "An S3 object key or path prefix",
+      "type": "string",
+      "minLength": 1
+    },
+    "required": [
+      "s3-bucket",
+      "s3-key"
+    ],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
Some initial schema and child schema proposals for the "run judgment parser" process.

Main schemas are:
* tre_schemas/judgment-available.json
* tre_schemas/parsed-judgment-available.json
* tre_schemas/judgment-parser-error.json

Child schemas for potential re-use elsewhere are:
* tre_schemas/tre-attachments.json
* tre_schemas/tre-error.json
* tre_schemas/tre-parser-output.json
* tre_schemas/tre-s3-location.json
