### PR TITLE
Feat/DTE-650 : Added example judgment packer message

### DIFF
--- a/json-examples/packed-judgment.json
+++ b/json-examples/packed-judgment.json
@@ -1,0 +1,15 @@
+{
+  "properties" : {
+    "messageType" : "uk.gov.nationalarchives.tre.messages.packed.judgment.JudgmentPacked",
+    "timestampMillis" : 23345678,
+    "function" : "dev-tre-judgment-packer",
+    "producer" : "TRE",
+    "executionId" : "executionId344",
+    "parentExecutionId" : null
+  },
+  "parameters" : {
+    "bundleFileURI" : "pre-signed url",
+    "metadataFilePath" : "path to the metadata file",
+    "metadataFileType" : "maybe the reference you provided."
+  }
+}


### PR DESCRIPTION
[DTE-650](https://national-archives.atlassian.net/browse/DTE-650?atlOrigin=eyJpIjoiNWNhMzVkNmNhMjA4NDhhM2ExODA4NzM3OTRiNjJmMDAiLCJwIjoiaiJ9)

Message example created to provide clarity, but schema not added as tre-event-lib not used in message generation.

[DTE-650]: https://national-archives.atlassian.net/browse/DTE-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ