### PR TITLE
DTE-721: incorporate errors in a status field

### DIFF
--- a/json-examples-new-schema/judgment-parse.json
+++ b/json-examples-new-schema/judgment-parse.json
@@ -8,9 +8,10 @@
     "parentExecutionId" : null
   },
   "parameters" : {
+    "status": "JUDGMENT-PARSE-NO-ERRORS",
     "originator" : "FCL",
     "s3FolderName" : "folder",
     "s3Bucket" : "bucket",
-    "reference" : "maybe the reference you provided."
+    "reference" : "the reference you provided."
   }
 }

--- a/json-examples-new-schema/judgmentpackage-available.json
+++ b/json-examples-new-schema/judgmentpackage-available.json
@@ -8,6 +8,7 @@
     "parentExecutionId" : "inputMessageExecutionId"
   },
   "parameters" : {
+    "status": "JUDGMENT-PARSE-NO-ERRORS",
     "reference" : "(TDR-2023-AAA|FCL-???????) # opaque string: use originator to know where it came from, should be an acceptable filename",
     "originator" : "FCL",
     "bundleFileURI" : "https://s3.amazonaws.com/tre-output/TDR-2023-AAA.tar.gz?X-Amz-Security-Token=24db05… # download tar.gz",

--- a/tre_schemas/avro/judgment-parsed.avsc
+++ b/tre_schemas/avro/judgment-parsed.avsc
@@ -36,6 +36,18 @@
             "name": "reference",
             "type": "string",
             "description": "request ref to allow user to be passed back to user"
+          },
+          {
+            "name": "status",
+            "type": {
+              "type": "enum",
+              "name": "Status",
+              "symbols": [
+                "JUDGMENT-PARSE-NO-ERRORS",
+                "JUDGMENT-PARSE-WITH-ERRORS"
+              ]
+            },
+            "doc": "The status as emitted by the parser. Could be used for filtering and redirecting messages"
           }
         ]
       }

--- a/tre_schemas/avro/judgmentpackage-available.avsc
+++ b/tre_schemas/avro/judgmentpackage-available.avsc
@@ -41,6 +41,18 @@
             "name": "metadataFileType",
             "type": "string",
             "doc": "type definition of the metadata file defined by a schema"
+          },
+          {
+            "name": "status",
+            "type": {
+              "type": "enum",
+              "name": "Status",
+              "symbols": [
+                "JUDGMENT-PARSE-NO-ERRORS",
+                "JUDGMENT-PARSE-WITH-ERRORS"
+              ]
+            },
+            "doc": "The status as emitted by the parser. Could be used for filtering and redirecting messages"
           }
         ]
       }


### PR DESCRIPTION
@ian-hoyle for your input on naming / enum for status field
- also have removed a `maybe` around `reference` example as suggests it might be optional, which it is not.
- be grateful if you could also confirm any code build from this not broken by my chages