### PR TITLE
release build improvements

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git config --global user.email digitalpreservation@nationalarchives.gov.uk
+git config --global user.name tna-digital-archiving-jenkins
+git checkout -b $BRANCH_NAME
+git push -u origin $BRANCH_NAME
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
           git_commit_gpgsign: true
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - run: ./.github/scripts/setup.sh
       - run: |
           sbt 'release with-defaults'
         env:
@@ -25,4 +26,4 @@ jobs:
       - name: Create Pull Request
         run: gh pr create --fill --label 'Version bump'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,13 @@
 import sbt.url
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
-name := "da-transform-schema"
-organization := "uk.gov.nationalarchives"
+ThisBuild / name := "da-transform-schema"
+ThisBuild / organization := "uk.gov.nationalarchives"
+
+// For all Sonatype accounts created on or after February 2021
+//ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+//sonatypeCredentialHost := "s01.oss.sonatype.org"
+//sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 scmInfo := Some(
   ScmInfo(
@@ -36,10 +41,10 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion, // set release version in version.sbt
   commitReleaseVersion, // commit the release version
   tagRelease, // create git tag
-  releaseStepCommandAndRemaining("+publishSigned"), // run +publishSigned command to sonatype stage release
+  releaseStepCommand("publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion, // set next version in version.sbt
   commitNextVersion, // commit next version
-  releaseStepCommand("sonatypeRelease"), // run sonatypeRelease and publish to maven central
   pushChanges // push changes to git
 )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1"
+ThisBuild / version := "0.101-SNAPSHOT"


### PR DESCRIPTION
The scripts now checkout a new branch and create pull request for release version bump
The uk.gov.nationalarchives organisation sonatype account created before Feb 2021 so comment out post repositories, left so can be used for personal testing.
sonatypeBundleRelease run sonatypeRelease so no need to run step separately

