### PR TITLE
Add metadata to request parse

### DIFF
--- a/json-examples-new-schema/request-courtdocument-parse.json
+++ b/json-examples-new-schema/request-courtdocument-parse.json
@@ -13,7 +13,14 @@
     "reference" : "FCL-12345",
     "originator" : "FCL",
     "parserInstructions" : {
-      "documentType" : "press-summary"
+      "documentType" : "pressSummary",
+      "metadata": {
+        "court": "EWHC-Chancery-Business",
+        "uri": "ewhc/ch/2023/1/press-summary/1",
+        "cite": "[2023] EWHC 1 (Ch)",
+        "name": "Green v. Purple",
+        "date": "2023-12-31"
+      }
     }
   }
 }

--- a/tre_schemas/avro/uk/gov/nationalarchives/da/messages/request/request-courtdocument-parse.avsc
+++ b/tre_schemas/avro/uk/gov/nationalarchives/da/messages/request/request-courtdocument-parse.avsc
@@ -48,7 +48,66 @@
                 {
                   "name": "documentType",
                   "type": "string",
-                  "doc": "type of court document to be parsed. press-summary|judgment"
+                  "doc": "type of court document to be parsed. pressSummary|judgment"
+                },
+                {
+                  "name": "metadata",
+                  "default": null,
+                  "doc": "Potentially human-edited metadata that should be preserved on a reparse. Null values mean that the parser should determine the value freely.",
+                  "type": [
+                    "null",
+                    {
+                      "type": "record",
+                      "name": "metadata_record",
+                      "fields": [
+                        {
+                          "name": "court",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "doc": "Court code like 'EWHC-Chancery-Business'",
+                          "default": null
+                        },
+                        {
+                          "name": "uri",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "doc": "Stripped FCL URI, like 'ewhc/ch/2023/1/press-summary/1'",
+                          "default": null
+                        },
+                        {
+                          "name": "cite",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "doc": "Neutral Citation in standard form, like '[2023] EWHC 1 (Ch)'",
+                          "default": null
+                        },
+                        {
+                          "name": "date",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "doc": "ISO 8601 date of the handing down of the document, like '2023-12-31'",
+                          "default": null
+                        },
+                        {
+                          "name": "name",
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "doc": "The name of the document. Format unspecified.",
+                          "default": null
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
Adds a metadata field to request-courtdocument-parse, to support retaining human-edited or approved metadata when reparsing a document.

I'm not quite clear whether I've successfully made the properties section and its subkeys optional.

Also changes "press-summary" to "pressSummary" where the documentation is inaccurate.