### PR TITLE
Fix typo in the default parsed judgment messageType string

### DIFF
--- a/tre_schemas/tre-parsed-judgement.json
+++ b/tre_schemas/tre-parsed-judgement.json
@@ -7,7 +7,7 @@
       "properties": {
         "messageType": {
           "type": "string",
-          "default": "uk,gov.nationalarchives.tre.messages.parsed.judgment.TREParsedJudgment",
+          "default": "uk.gov.nationalarchives.tre.messages.parsed.judgment.TREParsedJudgment",
           "doc": "Message for a parsed judgment event"
         },
         "timestampMillis": {


### PR DESCRIPTION
The default `messageType` was using `uk,gov.nationalarchives...` instead of `uk.gov.nationalarchives...`.

Switch the comma for a full stop.